### PR TITLE
Fix default to active contacts only

### DIFF
--- a/batdc/app/controllers/application_controller.rb
+++ b/batdc/app/controllers/application_controller.rb
@@ -37,9 +37,6 @@ class ApplicationController < ActionController::Base
   
   def prepare_for_mobile
     prepend_view_path Rails.root + 'app' + 'views_mobile'
-
-    # show only active contacts on mobile devices
-    params[:active_only] = true
     params[:mobile] = true
   end
 end

--- a/batdc/app/controllers/contacts_controller.rb
+++ b/batdc/app/controllers/contacts_controller.rb
@@ -12,7 +12,7 @@ class ContactsController < ApplicationController
       @contacts = @contacts.at_member
     end
 
-    @contacts = @contacts.status('Active') if params[:active_only]
+    @contacts = @contacts.status('Active') unless params[:show_inactive]
     @contacts = @contacts.search(params[:search]) unless params[:search].blank?
     @contacts = @contacts.in_region(params[:in_region]) unless params[:in_region].blank?
     @contacts = @contacts.at_school(params[:at_school]) unless params[:at_school].blank?

--- a/batdc/app/views/contacts/index.html.erb
+++ b/batdc/app/views/contacts/index.html.erb
@@ -4,8 +4,8 @@
     <%= form_tag(contacts_path, :method => "get", role: "search", id: "search-form") do %>
       <div class="input-group">
         <span class="input-group-addon" id="status">
-          <%= label_tag(:status, "Active") %>
-          <%= check_box_tag(:active_only, params[:active_only], params[:active_only], disabled: false, :onchange=>"this.form.submit();") %>
+          <%= label_tag(:status, "All") %>
+          <%= check_box_tag(:show_inactive, params[:show_inactive], params[:show_inactive], :onchange=>"this.form.submit();") %>
         </span>
         <% regions = ['Bay Area', 'Southern California', 'Other']%>
         <%= select_tag(:in_region, options_for_select(regions, params[:in_region]), class: "form-control", :onchange => "this.form.submit();", :include_blank => true) %>


### PR DESCRIPTION
Reverses the ‘polarity’ of the boolean so that the property becomes
:show_inactive instead of :active_only.